### PR TITLE
Use yq in comparison of templates got by helm manifest command

### DIFF
--- a/tests/functions.sh
+++ b/tests/functions.sh
@@ -43,3 +43,13 @@ function check_diff(){
         exit 1
     fi
 }
+
+function check_yq_version() {
+  readonly yq_version="$(yq --version | grep -oE '[^[:space:]]+$')"
+  readonly yq_major_version="${yq_version:0:1}"
+  readonly yq_min_version=4
+  if [[ "${yq_major_version}" < "${yq_min_version}" ]]; then
+    echo "Please install yq in version ${yq_min_version}.0 or higher"
+    exit 1
+  fi
+}

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -7,6 +7,8 @@ readonly ROOT_DIR="$(dirname "$(dirname "${0}")")"
 # shellcheck disable=SC1090
 source "${ROOT_DIR}/tests/functions.sh"
 
+check_yq_version
+
 readonly IMG="public.ecr.aws/sumologic/sumologic-kubernetes-collection-helm-operator:0.0.4"
 readonly NAMESPACE="sumologic-system"
 readonly TIME=900
@@ -94,5 +96,5 @@ sed -i.bak '/caBundle:/d' helm_operator_templates.yaml
 sed -i.bak '/caBundle:/d' helm_chart_templates.yaml
 
 
-DIFF="$(diff helm_operator_templates.yaml helm_chart_templates.yaml)"
+DIFF="$(diff <(yq e -P helm_operator_templates.yaml) <(yq e -P helm_chart_templates.yaml) )"
 check_diff "${DIFF}"

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -63,3 +63,7 @@ SHELLCHECK_VERSION=v0.7.1
 curl -Lo- "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" | tar -xJf -
 cp "shellcheck-${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin
 rm -rf "shellcheck-${SHELLCHECK_VERSION}/"
+
+YQ_VERSION=v4.7.1
+wget "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -O /usr/bin/yq &&\
+    chmod +x /usr/bin/yq


### PR DESCRIPTION
Used method showed here to compare yaml files: https://mikefarah.gitbook.io/yq/usage/tips-and-tricks#comparing-yaml-files to deal with different formatting of multiline strings.
Sometimes following difference occurs (content is the same but formatted differently despite the fact the templates are got using the same command):
![Screenshot 2021-05-06 at 09 24 10](https://user-images.githubusercontent.com/73836361/117258034-d3420980-ae4c-11eb-89be-0d703d944dda.png)
