### PR TITLE
operator: update images in bundle with all required templates

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -447,7 +447,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.6.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443
@@ -457,7 +457,7 @@ spec:
         - --metrics-bind-address=127.0.0.1:8080
         - --leader-elect
         - --leader-election-id=operator
-        image: public.ecr.aws/sumologic/sumologic-kubernetes-collection-helm-operator:0.0.0
+        image: public.ecr.aws/sumologic/sumologic-kubernetes-collection-helm-operator:0.0.4
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
`registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.6.0` - it is Red Hat certified image for kube-rbac-proxy