### PR TITLE
bundle: add specDescriptors with accessId and accessKey

### DIFF
--- a/bundle/manifests/operator.clusterserviceversion.yaml
+++ b/bundle/manifests/operator.clusterserviceversion.yaml
@@ -1657,6 +1657,17 @@ spec:
       - kind: SumologicCollection
         name: sumologiccollections.helm-operator.sumologic.com
         version: v1alpha1
+        specDescriptors:
+        - description: Sumo access ID
+          displayName: Access ID
+          path: sumologic.accessId
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:text
+        - description: Sumo access key
+          displayName: Access key
+          path: sumologic.accessKey
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:text
   description: Helm Operator for the Sumo Logic Kubernetes Collection Chart
   displayName: Sumo Logic Helm Operator
   icon:


### PR DESCRIPTION
Changes cause that accessID and accessKey can be provided from Form View
![Screenshot 2021-05-07 at 15 19 21](https://user-images.githubusercontent.com/73836361/117456480-86435d80-af48-11eb-8636-2a830ffe429c.png) 
The rest of configuration can provided from YAML View:
![Screenshot 2021-05-07 at 15 19 46](https://user-images.githubusercontent.com/73836361/117456597-ac68fd80-af48-11eb-9988-16622258cdd5.png)

