### PR TITLE
ci: add test to check if bundle.yaml is up to date

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -18,6 +18,14 @@ jobs:
       - name: shellcheck
         run: make shellcheck
 
+  test-bundle-status:
+    name: Test whether bundle.yaml is up to date
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check bundle.yaml
+        run: make test-bundle-status
+
   test-helm-operator:
     name: Test Helm operator
     runs-on: ubuntu-20.04

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ IMAGE_TAG_BASE ?= sumologic.com/operator
 BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
 
 # Image URL to use all building/pushing image targets
-IMG ?= controller:latest
+IMG ?= public.ecr.aws/sumologic/sumologic-kubernetes-collection-helm-operator:0.0.4
 
 all: docker-build
 
@@ -84,6 +84,9 @@ test-quick: deploy-receiver-mock deploy-helm-operator compare_manifests
 test-using-public-images: deploy-receiver-mock deploy-helm-chart deploy-helm-operator-using-public-images compare_manifests
 
 test-quick-using-public-images: deploy-receiver-mock deploy-helm-operator-using-public-images compare_manifests
+
+test-bundle-status:
+	tests/check_bundle_status.sh
 
 shellcheck:
 	tests/shellcheck.sh

--- a/tests/check_bundle_status.sh
+++ b/tests/check_bundle_status.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# The test will protect against forgetting about checking introduced changes in kustomize templates.
+# Content of bundle.yaml should be updated along with changes in templates for kustomize.
+
+readonly ROOT_DIR="$(dirname "$(dirname "${0}")")"
+
+# shellcheck disable=SC1090
+source "${ROOT_DIR}/tests/functions.sh"
+
+kustomize build config/default > generated_bundle.yaml
+DIFF="$(diff generated_bundle.yaml bundle.yaml)"
+check_diff "${DIFF}"


### PR DESCRIPTION
Added test will protect against forgetting about checking introduced changes in `kustomize` templates. 
`bundle.yaml` is used to deploy Helm operator without the need to generate templates using `kustomize`. Helm operator can be deployed by single command `kubectl apply -f bundle.yaml`.
 Content of `bundle.yaml` should be updated along with changes in templates for `kustomize`.