### PR TITLE
example: fix parsing of logs in CRI-O format

### DIFF
--- a/bundle/manifests/operator.clusterserviceversion.yaml
+++ b/bundle/manifests/operator.clusterserviceversion.yaml
@@ -289,7 +289,7 @@ metadata:
                               "extraFilterPluginConf": "",
                               "extraOutputPluginConf": "",
                               "multiline": {
-                                  "enabled": true
+                                  "enabled": false
                               }
                           },
                           "kubelet": {

--- a/config/samples/default_openshift.yaml
+++ b/config/samples/default_openshift.yaml
@@ -468,7 +468,7 @@ spec:
 
         ## To enable stiching multiline logs in fluentd when fluent-bit Multiline feature is On
         multiline:
-          enabled: true
+          enabled: false
 
       ## Kubelet log configuration
       kubelet:


### PR DESCRIPTION
according to:
https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/main/deploy/docs/ContainerLogs.md#configuration-for-cri-o-log-format

Openshift 4.6 uses CRI-O as container runtime