### PR TITLE
feat(samples/receiver_mock_openshift) disable multiline in config for Fluentd

### DIFF
--- a/config/samples/receiver_mock_openshift.yaml
+++ b/config/samples/receiver_mock_openshift.yaml
@@ -468,7 +468,7 @@ spec:
 
         ## To enable stiching multiline logs in fluentd when fluent-bit Multiline feature is On
         multiline:
-          enabled: true
+          enabled: false
 
       ## Kubelet log configuration
       kubelet:


### PR DESCRIPTION
ref: https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/release-v2.1/deploy/docs/ContainerLogs.md#configuration-for-cri-o-log-format

in default_openshift.yaml multiline is now disabled.