### PR TITLE
feat(samples/openshift): adjust samples to tested configuration

### DIFF
--- a/config/samples/default_openshift.yaml
+++ b/config/samples/default_openshift.yaml
@@ -267,8 +267,8 @@ spec:
       ## Increase number of http threads to Sumo. May be required in heavy logging/high DPM clusters
       numThreads: 8
       chunkLimitSize: "1m"
-      queueChunkLimitSize: 128
-      totalLimitSize: "128m"
+      queueChunkLimitSize: 256
+      totalLimitSize: "256m"
       retryMaxInterval: "10m"
       retryForever: true
       compress: gzip
@@ -794,7 +794,7 @@ spec:
       repository: sumologic/metrics-server
       tag: 0.4.2-debian-10-r58-ubi
     apiService:
-      create: true
+      create: false
     extraArgs:
       kubelet-insecure-tls: true
       kubelet-preferred-address-types: InternalIP,ExternalIP,Hostname

--- a/config/samples/receiver_mock_openshift.yaml
+++ b/config/samples/receiver_mock_openshift.yaml
@@ -794,7 +794,7 @@ spec:
       repository: sumologic/metrics-server
       tag: 0.4.2-debian-10-r58-ubi
     apiService:
-      create: true
+      create: false
     extraArgs:
       kubelet-insecure-tls: true
       kubelet-preferred-address-types: InternalIP,ExternalIP,Hostname

--- a/tests/deploy_helm_chart.sh
+++ b/tests/deploy_helm_chart.sh
@@ -23,6 +23,7 @@ helm install test-openshift sumologic/sumologic \
   --set kube-prometheus-stack.prometheus-node-exporter.service.targetPort=9200 \
   --set fluentd.buffer.queueChunkLimitSize=256 \
   --set fluentd.buffer.totalLimitSize="256m" \
+  --set fluentd.logs.containers.multiline.enabled=false \
   --set metrics-server.enabled=true \
   --set metrics-server.apiService.create=false \
   --set otelagent.enabled=true \

--- a/tests/test_openshift.yaml
+++ b/tests/test_openshift.yaml
@@ -468,7 +468,7 @@ spec:
 
         ## To enable stiching multiline logs in fluentd when fluent-bit Multiline feature is On
         multiline:
-          enabled: true
+          enabled: false
 
       ## Kubelet log configuration
       kubelet:


### PR DESCRIPTION
In tested configuration for helm chart it is set:
```
--set fluentd.buffer.queueChunkLimitSize=256 \
--set fluentd.buffer.totalLimitSize="256m"
```

`apiService` is available by default on OpenShift so it cannot be created when metrics-server is enabled.

`--set fluentd.logs.containers.multiline.enabled=false` according to this doc: https://github.com/SumoLogic/sumologic-kubernetes-collection/blob/release-v2.1/deploy/docs/ContainerLogs.md#configuration-for-cri-o-log-format