### PR TITLE
chore: update base image for Helm Operator to offical image from v1.11.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM ghcr.io/kkujawa-sumo/helm-operator:v1.10.0-9-ga4b99a8b
+FROM quay.io/operator-framework/helm-operator:v1.11.0
 
 ARG VERSION=${VERSION}
 ARG RELEASE_NUMBER=${RELEASE_NUMBER}


### PR DESCRIPTION
Update to https://github.com/operator-framework/operator-sdk/releases/tag/v1.11.0
It contains necessary changes from https://github.com/operator-framework/operator-sdk/pull/5105