### PR TITLE
fix: use dash instead of comma in OpenShift versions

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -15,7 +15,7 @@ LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
 LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 
 # Red Hat labels.
-LABEL com.redhat.openshift.versions="v4.6,v4.7"
+LABEL com.redhat.openshift.versions="v4.6-v4.7"
 LABEL com.redhat.delivery.operator.bundle=true
 LABEL operators.operatorframework.io.bundle.channel.default.v1=alpha
 

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -14,6 +14,6 @@ annotations:
   operators.operatorframework.io.test.config.v1: tests/scorecard/
 
   # Red Hat annotations.
-  com.redhat.openshift.versions: v4.6,v4.7
+  com.redhat.openshift.versions: v4.6-v4.7
   com.redhat.delivery.operator.bundle: true
   operators.operatorframework.io.bundle.channel.default.v1: alpha


### PR DESCRIPTION
see: https://github.com/operator-framework/community-operators/blob/8a36a3373bd146daa8b7509b9ddb1e9c06498e3d/docs/packaging-required-criteria-ocp.md