### PR TITLE
fix(ci): fix installation of Operator Package Manager

### DIFF
--- a/.github/workflows/dev_builds.yaml
+++ b/.github/workflows/dev_builds.yaml
@@ -20,8 +20,8 @@ jobs:
       - uses: actions/checkout@v2.3.4
 
       - name: Install Operator Package Manager (OPM)
-        run: wget -q "https://github.com/operator-framework/operator-registry/releases/download/${OPM_VERSION}/linux-amd64-opm" -O /usr/bin/opm && \
-          chmod +x /usr/bin/opm
+        run: sudo wget -q "https://github.com/operator-framework/operator-registry/releases/download/${OPM_VERSION}/linux-amd64-opm" -O /usr/bin/opm && \
+          sudo chmod +x /usr/bin/opm
         env:
           OPM_VERSION: v1.14.3
 

--- a/.github/workflows/release_builds.yaml
+++ b/.github/workflows/release_builds.yaml
@@ -25,8 +25,8 @@ jobs:
       - uses: actions/checkout@v2.3.4
 
       - name: Install Operator Package Manager (OPM)
-        run: wget -q "https://github.com/operator-framework/operator-registry/releases/download/${OPM_VERSION}/linux-amd64-opm" -O /usr/bin/opm && \
-          chmod +x /usr/bin/opm
+        run: sudo wget -q "https://github.com/operator-framework/operator-registry/releases/download/${OPM_VERSION}/linux-amd64-opm" -O /usr/bin/opm && \
+          sudo chmod +x /usr/bin/opm
         env:
           OPM_VERSION: v1.14.3
 


### PR DESCRIPTION
add missing sudo privileges, 
It is needed because of this failure: https://github.com/SumoLogic/sumologic-kubernetes-collection-helm-operator/actions/runs/1494683987