### PR TITLE
 fix(ci): change formatting of command used to install Operator Package Manager

### DIFF
--- a/.github/workflows/dev_builds.yaml
+++ b/.github/workflows/dev_builds.yaml
@@ -20,8 +20,8 @@ jobs:
       - uses: actions/checkout@v2.3.4
 
       - name: Install Operator Package Manager (OPM)
-        run: sudo wget -q "https://github.com/operator-framework/operator-registry/releases/download/${OPM_VERSION}/linux-amd64-opm" -O /usr/bin/opm && \
-          sudo chmod +x /usr/bin/opm
+        run: |
+          sudo wget -q "https://github.com/operator-framework/operator-registry/releases/download/${OPM_VERSION}/linux-amd64-opm" -O /usr/bin/opm && sudo chmod +x /usr/bin/opm
         env:
           OPM_VERSION: v1.14.3
 

--- a/.github/workflows/release_builds.yaml
+++ b/.github/workflows/release_builds.yaml
@@ -25,8 +25,8 @@ jobs:
       - uses: actions/checkout@v2.3.4
 
       - name: Install Operator Package Manager (OPM)
-        run: sudo wget -q "https://github.com/operator-framework/operator-registry/releases/download/${OPM_VERSION}/linux-amd64-opm" -O /usr/bin/opm && \
-          sudo chmod +x /usr/bin/opm
+        run: |
+          sudo wget -q "https://github.com/operator-framework/operator-registry/releases/download/${OPM_VERSION}/linux-amd64-opm" -O /usr/bin/opm && sudo chmod +x /usr/bin/opm
         env:
           OPM_VERSION: v1.14.3
 


### PR DESCRIPTION
Needed because of this failure: https://github.com/SumoLogic/sumologic-kubernetes-collection-helm-operator/runs/4300136614?check_suite_focus=true

Tested on fork: https://github.com/kkujawa-sumo/sumologic-kubernetes-collection-helm-operator/runs/4300997045?check_suite_focus=true
<img width="988" alt="Screenshot 2021-11-23 at 16 18 44" src="https://user-images.githubusercontent.com/73836361/143051694-674e4a97-c73e-4563-83ff-68a6b10b6966.png">


