### PR TITLE
chore: update Fluentd to 1.14.6-sumo-3 in bundle.yaml

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -495,7 +495,7 @@ spec:
         - name: RELATED_IMAGE_TELEGRAF
           value: registry.connect.redhat.com/sumologic/telegraf@sha256:8d92cabdd8efbec83475a004209745cc14e877d361cae19ab80a622ebda57e24
         - name: RELATED_IMAGE_KUBERNETES_FLUENTD
-          value: registry.connect.redhat.com/sumologic/kubernetes-fluentd@sha256:362053ce1833aa51db31d36f97458f526d199bcd7efff53486b09e3a02a795ab
+          value: public.ecr.aws/sumologic/kubernetes-fluentd@sha256:335728fa6711b8198ef814f60427f665f384965208baa91cf5cbafd278c1a9d8
         - name: RELATED_IMAGE_FLUENT_BIT
           value: registry.connect.redhat.com/sumologic/fluent-bit@sha256:faa802d22e41f8d67d487e40285fa2a7ea72f9cd49c32ddb80ea34f4d302e220
         - name: RELATED_IMAGE_SUMO_UBI_MINIMAL

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -68,7 +68,7 @@ spec:
           - name: RELATED_IMAGE_TELEGRAF
             value: registry.connect.redhat.com/sumologic/telegraf@sha256:8d92cabdd8efbec83475a004209745cc14e877d361cae19ab80a622ebda57e24
           - name: RELATED_IMAGE_KUBERNETES_FLUENTD
-            value: registry.connect.redhat.com/sumologic/kubernetes-fluentd@sha256:362053ce1833aa51db31d36f97458f526d199bcd7efff53486b09e3a02a795ab
+            value: public.ecr.aws/sumologic/kubernetes-fluentd@sha256:335728fa6711b8198ef814f60427f665f384965208baa91cf5cbafd278c1a9d8
           - name: RELATED_IMAGE_FLUENT_BIT
             value: registry.connect.redhat.com/sumologic/fluent-bit@sha256:faa802d22e41f8d67d487e40285fa2a7ea72f9cd49c32ddb80ea34f4d302e220
           - name: RELATED_IMAGE_SUMO_UBI_MINIMAL

--- a/config/samples/default_openshift.yaml
+++ b/config/samples/default_openshift.yaml
@@ -37,6 +37,10 @@ spec:
         ## To enable stiching multiline logs in fluentd when fluent-bit Multiline feature is On
         multiline:
           enabled: false
+    metadata:
+      ## Option to specify K8s API groups
+      apiGroups:
+        - apps/v1
 
   ## Configure fluent-bit
   ## ref: https://github.com/fluent/helm-charts/blob/master/charts/fluent-bit/values.yaml

--- a/tests/test_openshift.yaml
+++ b/tests/test_openshift.yaml
@@ -799,7 +799,7 @@ spec:
   metrics-server:
     ## Set the enabled flag to true for enabling metrics-server.
     ## This is required before enabling fluentd autoscaling unless you have an existing metrics-server in the cluster.
-    enabled: true
+    enabled: false
     image:
       registry: public.ecr.aws
       repository: sumologic/metrics-server


### PR DESCRIPTION
chore: update Fluentd to 1.14.6-sumo-3 in bundle.yaml
to enable deployment on OpenShift 4.9 and higher
details in: https://github.com/SumoLogic/sumologic-kubernetes-fluentd/pull/366

chore: update example configuration to support OpenShift 4.9 and higher
This removes the API group extensions/v1beta1, which does not exist in Kubernetes 1.22.
related to: https://github.com/SumoLogic/sumologic-kubernetes-collection/pull/1892