### PR TITLE
fix: change operator image to publicly available image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ IMAGE_TAG_BASE ?= sumologic.com/operator
 BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
 
 # Image URL to use all building/pushing image targets
-IMG ?= registry.connect.redhat.com/sumologic/sumologic-kubernetes-collection-helm-operator:2.14.1-0-rc.0
+IMG ?= public.ecr.aws/sumologic/sumologic-kubernetes-collection-helm-operator:2.14.1-0-rc.0
 
 all: docker-build
 

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -508,7 +508,7 @@ spec:
           value: public.ecr.aws/sumologic/sumologic-otel-collector:0.54.0-sumo-0@sha:sha256:b615e9e2cba4c3ec2d43146fcaf42dc132a0ba2d606933b1fa3324265991fac0
         - name: RELATED_IMAGE_OPENTELEMETRY_OPERATOR
           value: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator@sha256:148960f590a96fb000b2ff2accb33d131e52649006ef24a0c572664b8d2c9644
-        image: registry.connect.redhat.com/sumologic/sumologic-kubernetes-collection-helm-operator:2.14.1-0-rc.0
+        image: public.ecr.aws/sumologic/sumologic-kubernetes-collection-helm-operator:2.14.1-0-rc.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/bundle/manifests/operator.clusterserviceversion.yaml
+++ b/bundle/manifests/operator.clusterserviceversion.yaml
@@ -94,7 +94,7 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Logging & Tracing,Monitoring
-    containerImage: registry.connect.redhat.com/sumologic/sumologic-kubernetes-collection-helm-operator:2.14.1-0-rc.0
+    containerImage: public.ecr.aws/sumologic/sumologic-kubernetes-collection-helm-operator:2.14.1-0-rc.0
     createdAt: "2022-08-04T13:09:07Z"
     repository: https://github.com/SumoLogic/sumologic-kubernetes-collection-helm-operator.git
     support: Sumo Logic
@@ -466,7 +466,7 @@ spec:
                         value: public.ecr.aws/sumologic/sumologic-otel-collector:0.54.0-sumo-0@sha:sha256:b615e9e2cba4c3ec2d43146fcaf42dc132a0ba2d606933b1fa3324265991fac0
                       - name: RELATED_IMAGE_OPENTELEMETRY_OPERATOR
                         value: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator@sha256:148960f590a96fb000b2ff2accb33d131e52649006ef24a0c572664b8d2c9644
-                    image: registry.connect.redhat.com/sumologic/sumologic-kubernetes-collection-helm-operator:2.14.1-0-rc.0
+                    image: public.ecr.aws/sumologic/sumologic-kubernetes-collection-helm-operator:2.14.1-0-rc.0
                     livenessProbe:
                       httpGet:
                         path: /healthz

--- a/tests/deploy_helm_operator.sh
+++ b/tests/deploy_helm_operator.sh
@@ -33,7 +33,7 @@ readonly TIME=900
 # sed -i.bak "s#registry.connect.redhat.com/sumologic/opentelemetry-collector@#public.ecr.aws/sumologic/opentelemetry-collector#g" bundle.yaml
 
 # Change image in bundle.yaml to imag
-sed -i.bak "s#registry.connect.redhat.com/sumologic/sumologic-kubernetes-collection-helm-operator:2.14.1-0-rc.0#${IMG}#g" bundle.yaml
+sed -i.bak "s#public.ecr.aws/sumologic/sumologic-kubernetes-collection-helm-operator:2.14.1-0-rc.0#${IMG}#g" bundle.yaml
 
 kubectl apply -f bundle.yaml
 


### PR DESCRIPTION
new version in `registry.connect.redhat.com` is not available at this moment