### PR TITLE
fix(opentelemetry-operator): add opentelemetry.io to ClusterRole for Helm operator

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -338,6 +338,12 @@ rules:
   - priorityclasses
   verbs:
   - '*'
+- apiGroups:
+  - opentelemetry.io
+  resources:
+  - instrumentations
+  verbs:
+  - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/bundle/manifests/operator.clusterserviceversion.yaml
+++ b/bundle/manifests/operator.clusterserviceversion.yaml
@@ -388,6 +388,12 @@ spec:
                 - subjectaccessreviews
               verbs:
                 - create
+            - apiGroups:
+                - opentelemetry.io
+              resources:
+                - instrumentations
+              verbs:
+                - '*'
           serviceAccountName: sumologic-helm-operator
       deployments:
         - label:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -242,5 +242,11 @@ rules:
   - priorityclasses
   verbs:
   - '*'
+- apiGroups:
+  - opentelemetry.io
+  resources:
+  - instrumentations
+  verbs:
+  - '*'
 
 #+kubebuilder:scaffold:rules


### PR DESCRIPTION
It is needed to fix following error:
```
{"level":"error","ts":1661782757.6607969,"msg":"Reconciler error","controller":"sumologiccollection-controller","object":{"name":"collection","namespace":"sumologic-system"},"namespace":"sumologic-system","name":"collection","reconcileID":"2a08efd6-5a28-4ac0-8c63-d4ce5e69d00a","error":"failed to install release: failed post-install: instrumentations.opentelemetry.io \"collection-sumologic-ot-operator-instr\" is forbidden: User \"system:serviceaccount:sumologic-system:sumologic-helm-operator\" cannot delete resource \"instrumentations\" in API group \"opentelemetry.io\" in the namespace \"sumologic-system\"","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.2/pkg/internal/controller/controller.go:273\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.2/pkg/internal/controller/controller.go:234"}

```