### PR TITLE
chore: update k8s in vagrant environment

### DIFF
--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -18,7 +18,7 @@ apt-get install --yes docker-ce docker-ce-cli containerd.io
 usermod -aG docker vagrant
 
 # Install k8s
-snap install microk8s --classic --channel=1.19/stable
+snap install microk8s --classic --channel=1.23/stable
 microk8s.status --wait-ready
 ufw allow in on cbr0
 ufw allow out on cbr0
@@ -32,7 +32,7 @@ microk8s.kubectl config view --raw > /operator/.kube-config
 
 usermod -a -G microk8s vagrant
 
-snap install kubectl --classic --channel=1.19/stable
+snap install kubectl --classic --channel=1.23/stable
 
 echo "export KUBECONFIG=/var/snap/microk8s/current/credentials/kubelet.config" >> /home/vagrant/.bashrc
 


### PR DESCRIPTION
OpenShift 4.10 uses k8s 1.23