### PR TITLE
feat: add script to get list of image configuration keys for the Sumo Logic Helm Chart

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,5 @@
+# Scripts
+
+Description of scripts in this directory:
+
+- [get_image_config_keys.py](./get_image_config_keys.py) - script to get list of image configuration keys for the Sumo Logic Kubernetes Collection Helm Chart


### PR DESCRIPTION
Output of the script:
```
debug.sumologicMock.image.repository
debug.sumologicMock.image.tag
kube-prometheus-stack.kube-state-metrics.image.repository
kube-prometheus-stack.kube-state-metrics.image.tag
kube-prometheus-stack.prometheus-node-exporter.image.repository
kube-prometheus-stack.prometheus-node-exporter.image.tag
kube-prometheus-stack.prometheus.prometheusSpec.image.repository
kube-prometheus-stack.prometheus.prometheusSpec.image.sha
kube-prometheus-stack.prometheus.prometheusSpec.image.tag
kube-prometheus-stack.prometheusOperator.image.repository
kube-prometheus-stack.prometheusOperator.image.sha
kube-prometheus-stack.prometheusOperator.image.tag
kube-prometheus-stack.prometheusOperator.prometheusConfigReloader.image.repository
kube-prometheus-stack.prometheusOperator.prometheusConfigReloaderImage.sha
kube-prometheus-stack.prometheusOperator.prometheusConfigReloaderImage.tag
kube-prometheus-stack.prometheusOperator.thanosImage.repository
kube-prometheus-stack.prometheusOperator.thanosImage.sha
kube-prometheus-stack.prometheusOperator.thanosImage.tag
metadata.image.repository
metadata.image.tag
metrics-server.image.registry
metrics-server.image.repository
metrics-server.image.tag
opentelemetry-operator.instrumentation.dotnet.image
opentelemetry-operator.instrumentation.dotnet.repository
opentelemetry-operator.instrumentation.dotnet.tag
opentelemetry-operator.instrumentation.java.image
opentelemetry-operator.instrumentation.java.repository
opentelemetry-operator.instrumentation.java.tag
opentelemetry-operator.instrumentation.nodejs.image
opentelemetry-operator.instrumentation.nodejs.repository
opentelemetry-operator.instrumentation.nodejs.tag
opentelemetry-operator.instrumentation.python.image
opentelemetry-operator.instrumentation.python.repository
opentelemetry-operator.instrumentation.python.tag
opentelemetry-operator.instrumentationJobImage.image.repository
opentelemetry-operator.instrumentationJobImage.image.tag
opentelemetry-operator.kubeRBACProxy.image.repository
opentelemetry-operator.kubeRBACProxy.image.repository.tag
opentelemetry-operator.manager.collectorImage.repository
opentelemetry-operator.manager.collectorImage.tag
opentelemetry-operator.manager.image.repository
opentelemetry-operator.manager.image.repository.tag
opentelemetry-operator.testFramework.image.repository
opentelemetry-operator.testFramework.image.repository.tag
otelcolInstrumentation.statefulset.image.repository
otelcolInstrumentation.statefulset.image.tag
otelevents.image.repository
otelevents.image.tag
otellogs.daemonset.initContainers.changeowner.image.repository
otellogs.daemonset.initContainers.changeowner.image.tag
otellogs.image.repository
otellogs.image.tag
otellogswindows.daemonset.initContainers.prepare.image.repository
otellogswindows.daemonset.initContainers.prepare.image.tag
otellogswindows.image.repository
otellogswindows.image.tag
pvcCleaner.job.image.repository
pvcCleaner.job.image.tag
sumologic.metrics.collector.otelcol.image.repository
sumologic.metrics.collector.otelcol.image.tag
sumologic.metrics.remoteWriteProxy.image.repository
sumologic.metrics.remoteWriteProxy.image.tag
sumologic.otelcolImage.repository
sumologic.otelcolImage.tag
sumologic.setup.job.image.repository
sumologic.setup.job.image.tag
sumologic.setup.job.initContainerImage.repository
sumologic.setup.job.initContainerImage.tag
tailing-sidecar-operator.kubeRbacProxy.image.repository
tailing-sidecar-operator.kubeRbacProxy.image.tag
tailing-sidecar-operator.operator.image.repository
tailing-sidecar-operator.operator.image.tag
tailing-sidecar-operator.sidecar.image.repository
tailing-sidecar-operator.sidecar.image.tag
telegraf-operator.image.repository
telegraf-operator.image.sidecarImage
telegraf-operator.image.tag
tracesGateway.deployment.image.repository
tracesGateway.deployment.image.tag
tracesSampler.deployment.image.repository
tracesSampler.deployment.image.tag
```