### PR TITLE
feat: add script to generate watches.yaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,3 +229,6 @@ catalog-push: ## Push a catalog image.
 
 update-components-images:
 	./scripts/update_images.py --images-file=$(IMAGES_FILE)
+
+generate-watches:
+	./scripts/generate_watches.py

--- a/scripts/generate_watches.py
+++ b/scripts/generate_watches.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+
+from get_image_config_keys import get_image_keys
+import argparse
+import yaml
+import os
+
+WATCHES_PATH = "watches.yaml"
+
+def create_new_file_path(file_path: str, create_new_file: bool) -> str:
+    """Creates path for the file with updated list of components images
+
+    Args:
+        file_path (str): path to file in which components images should be updated
+        create_new_file: determines whether new yaml should be created or the exiting file should be overwritten
+
+    Returns:
+        str: path to file in which changes will be save
+    """
+    new_file_path = file_path
+    if create_new_file:
+        new_file_path = file_path.replace(".yaml", "_new.yaml")
+    return new_file_path
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--operator-repo-dir", help="path to directory with Helm Operator repository, e.g. /operator/", default="./")
+    parser.add_argument("--create-new-file", help="determines whether new yaml should be created or the exiting file should be overwritten", default=True)
+    return parser.parse_args()
+
+if __name__ == '__main__':
+    """
+    Generates watches.yaml based on values.yaml for the Sumo Logic Kubernetes Collection Helm Chart
+    Environment variables related to new image keys need to be manually filled out
+    """
+    args = parse_args()
+
+    image_keys = get_image_keys()
+    watches_file_path = os.path.join(args.operator_repo_dir, WATCHES_PATH)
+
+    with open(watches_file_path) as w:
+      watches = yaml.safe_load(w)
+      overrideValues = watches[0]["overrideValues"]
+
+      for image_key in image_keys:
+          if image_key not in watches[0]["overrideValues"].keys():
+            overrideValues[image_key] = ""
+
+      with open(create_new_file_path(watches_file_path, args.create_new_file), 'w') as nw:
+            yaml.safe_dump(watches, nw)

--- a/scripts/get_image_config_keys.py
+++ b/scripts/get_image_config_keys.py
@@ -14,7 +14,7 @@ def values_to_dictionary(url: str) -> dict:
     Returns:
         dict: values.yaml as dict
     """
-    with urllib.request.urlopen(values_url) as response:
+    with urllib.request.urlopen(url) as response:
         values = response.read().decode(response.headers.get_content_charset())
         values = re.sub(r'(\[\]|\{\})\n(\s+# )', r'\n\2', values, flags=re.M)
         values = re.sub(r'^(\s+)# ', r'\1', values, flags=re.M)
@@ -73,7 +73,12 @@ known_image_keys = [
 not_needed_image_keys = ["Percentage", "falco", "pullPolicy", "pullSecrets", "imagePullSecrets"]
 needed_image_keys = ["image", "tag", "repository"]
 
-if __name__ == '__main__':
+def get_image_keys()-> list:
+    """Gets list of image configuration keys for the Sumo Logic Kubernetes Collection Helm Chart
+
+    Returns:
+        list: list of image configuration keys for the Sumo Logic Kubernetes Collection Helm Chart
+    """
     values_url = "https://raw.githubusercontent.com/SumoLogic/sumologic-kubernetes-collection/main/deploy/helm/sumologic/values.yaml"
 
     values = values_to_dictionary(values_url)
@@ -97,5 +102,8 @@ if __name__ == '__main__':
 
     image_keys.extend(known_image_keys)
     image_keys.sort()
-    
+    return image_keys
+
+if __name__ == '__main__':
+    image_keys = get_image_keys()
     print("\n".join(image_keys))

--- a/scripts/update_images.py
+++ b/scripts/update_images.py
@@ -2,6 +2,7 @@
 
 import yaml
 import argparse
+import os 
 
 RED_HAT_REGISTRY = "registry.connect.redhat.com/sumologic/"
 ENV_PREFIX = "RELATED_IMAGE_"
@@ -175,8 +176,8 @@ if __name__ == '__main__':
 
     related_images, image_envs = generate_image_lists(args.images_file)
 
-    csv_path = args.operator_repo_dir + CLUSTER_SERVICE_VERSION_PATH
+    csv_path = os.path.join(args.operator_repo_dir, CLUSTER_SERVICE_VERSION_PATH)
     update_cluster_service_version(csv_path, related_images, image_envs, args.create_new_file)
 
-    m_path = args.operator_repo_dir  + MANAGER_PATH
+    m_path = os.path.join(args.operator_repo_dir, MANAGER_PATH)
     update_manager(m_path, image_envs, args.create_new_file)

--- a/watches.yaml
+++ b/watches.yaml
@@ -1,49 +1,83 @@
-# Use the 'create api' subcommand to add watches to this file.
-- group: helm-operator.sumologic.com
-  version: v1alpha1
+- chart: helm-charts/sumologic
+  group: helm-operator.sumologic.com
   kind: SumologicCollection
-  chart: helm-charts/sumologic
   overrideValues:
-    sumologic.setup.job.image.repository: '{{ ("$RELATED_IMAGE_KUBERNETES_SETUP" | split ":")._0 }}'
-    sumologic.setup.job.image.tag: '{{ ("$RELATED_IMAGE_KUBERNETES_SETUP" | split ":")._1 }}'
-    fluentd.image.repository: '{{ ("$RELATED_IMAGE_KUBERNETES_FLUENTD" | split ":")._0 }}'
-    fluentd.image.tag: '{{ ("$RELATED_IMAGE_KUBERNETES_FLUENTD" | split ":")._1 }}'
-    metrics-server.image.registry: '{{ ("$RELATED_IMAGE_METRICS_SERVER" | split "/")._0 }}'
-    metrics-server.image.repository: '{{ (("$RELATED_IMAGE_METRICS_SERVER" | split ":")._0 | split "/")._1 }}/{{ (("$RELATED_IMAGE_METRICS_SERVER" | split ":")._0 | split "/")._2 }}'
-    metrics-server.image.tag: '{{ ("$RELATED_IMAGE_METRICS_SERVER" | split ":")._1 }}'
-    fluent-bit.image.repository: '{{ ("$RELATED_IMAGE_FLUENT_BIT" | split ":")._0 }}'
+    fluent-bit.image.repository: '{{ ("$RELATED_IMAGE_FLUENT_BIT" | split ":")._0
+      }}'
     fluent-bit.image.tag: '{{ ("$RELATED_IMAGE_FLUENT_BIT" | split ":")._1 }}'
-    kube-prometheus-stack.prometheusOperator.image.repository: '{{ ("$RELATED_IMAGE_PROMETHEUS_OPERATOR" | split "@")._0 }}'
-    kube-prometheus-stack.prometheusOperator.image.tag: v0.44.0
-    kube-prometheus-stack.prometheusOperator.image.sha: '{{ ("$RELATED_IMAGE_PROMETHEUS_OPERATOR" | split ":")._1 }}'
-    kube-prometheus-stack.prometheusOperator.prometheusConfigReloaderImage.repository: '{{ ("$RELATED_IMAGE_PROMETHEUS_CONFIG_RELOADER" | split "@")._0 }}'
-    kube-prometheus-stack.prometheusOperator.prometheusConfigReloaderImage.tag: v0.44.0
-    kube-prometheus-stack.prometheusOperator.prometheusConfigReloaderImage.sha: '{{ ("$RELATED_IMAGE_PROMETHEUS_CONFIG_RELOADER" | split ":")._1 }}'
-    kube-prometheus-stack.kube-state-metrics.image.repository: '{{ ("$RELATED_IMAGE_KUBE_STATE_METRICS" | split ":")._0 }}'
-    kube-prometheus-stack.kube-state-metrics.image.tag: '{{ ("$RELATED_IMAGE_KUBE_STATE_METRICS" | split ":")._1 }}'
-    kube-prometheus-stack.prometheus-node-exporter.image.repository: '{{ ("$RELATED_IMAGE_NODE_EXPORTER" | split ":")._0 }}'
-    kube-prometheus-stack.prometheus-node-exporter.image.tag: '{{ ("$RELATED_IMAGE_NODE_EXPORTER" | split ":")._1 }}'
-    kube-prometheus-stack.prometheus.prometheusSpec.image.repository: '{{ ("$RELATED_IMAGE_PROMETHEUS" | split "@")._0 }}'
+    fluentd.image.repository: '{{ ("$RELATED_IMAGE_KUBERNETES_FLUENTD" | split ":")._0
+      }}'
+    fluentd.image.tag: '{{ ("$RELATED_IMAGE_KUBERNETES_FLUENTD" | split ":")._1 }}'
+    kube-prometheus-stack.kube-state-metrics.image.repository: '{{ ("$RELATED_IMAGE_KUBE_STATE_METRICS"
+      | split ":")._0 }}'
+    kube-prometheus-stack.kube-state-metrics.image.tag: '{{ ("$RELATED_IMAGE_KUBE_STATE_METRICS"
+      | split ":")._1 }}'
+    kube-prometheus-stack.prometheus-node-exporter.image.repository: '{{ ("$RELATED_IMAGE_NODE_EXPORTER"
+      | split ":")._0 }}'
+    kube-prometheus-stack.prometheus-node-exporter.image.tag: '{{ ("$RELATED_IMAGE_NODE_EXPORTER"
+      | split ":")._1 }}'
+    kube-prometheus-stack.prometheus.prometheusSpec.image.repository: '{{ ("$RELATED_IMAGE_PROMETHEUS"
+      | split "@")._0 }}'
+    kube-prometheus-stack.prometheus.prometheusSpec.image.sha: '{{ ("$RELATED_IMAGE_PROMETHEUS"
+      | split ":")._1 }}'
     kube-prometheus-stack.prometheus.prometheusSpec.image.tag: v2.22.1
-    kube-prometheus-stack.prometheus.prometheusSpec.image.sha: '{{ ("$RELATED_IMAGE_PROMETHEUS" | split ":")._1 }}'
     kube-prometheus-stack.prometheus.prometheusSpec.thanos.image: $RELATED_IMAGE_THANOS
-    otelagent.daemonset.image.repository: '{{ ("$RELATED_IMAGE_SUMOLOGIC_OTEL_COLLECTOR" | split ":")._0 }}'
-    otelagent.daemonset.image.tag: '{{ ("$RELATED_IMAGE_SUMOLOGIC_OTEL_COLLECTOR" | split ":")._1 }}'
-    otelcol.deployment.image.repository: '{{ ("$RELATED_IMAGE_SUMOLOGIC_OTEL_COLLECTOR" | split ":")._0 }}'
-    otelcol.deployment.image.tag: '{{ ("$RELATED_IMAGE_SUMOLOGIC_OTEL_COLLECTOR" | split ":")._1 }}'
-    telegraf-operator.image.repository: '{{ ("$RELATED_IMAGE_TELEGRAF_OPERATOR" | split ":")._0 }}'
-    telegraf-operator.image.tag: '{{ ("$RELATED_IMAGE_TELEGRAF_OPERATOR" | split ":")._1 }}'
+    kube-prometheus-stack.prometheusOperator.image.repository: '{{ ("$RELATED_IMAGE_PROMETHEUS_OPERATOR"
+      | split "@")._0 }}'
+    kube-prometheus-stack.prometheusOperator.image.sha: '{{ ("$RELATED_IMAGE_PROMETHEUS_OPERATOR"
+      | split ":")._1 }}'
+    kube-prometheus-stack.prometheusOperator.image.tag: v0.44.0
+    kube-prometheus-stack.prometheusOperator.prometheusConfigReloaderImage.repository: '{{
+      ("$RELATED_IMAGE_PROMETHEUS_CONFIG_RELOADER" | split "@")._0 }}'
+    kube-prometheus-stack.prometheusOperator.prometheusConfigReloaderImage.sha: '{{
+      ("$RELATED_IMAGE_PROMETHEUS_CONFIG_RELOADER" | split ":")._1 }}'
+    kube-prometheus-stack.prometheusOperator.prometheusConfigReloaderImage.tag: v0.44.0
+    metadata.image.repository: '{{ ("$RELATED_IMAGE_SUMOLOGIC_OTEL_COLLECTOR" | split
+      ":")._0 }}'
+    metadata.image.tag: '{{ ("$RELATED_IMAGE_SUMOLOGIC_OTEL_COLLECTOR" | split ":")._1
+      }}'
+    metrics-server.image.registry: '{{ ("$RELATED_IMAGE_METRICS_SERVER" | split "/")._0
+      }}'
+    metrics-server.image.repository: '{{ (("$RELATED_IMAGE_METRICS_SERVER" | split
+      ":")._0 | split "/")._1 }}/{{ (("$RELATED_IMAGE_METRICS_SERVER" | split ":")._0
+      | split "/")._2 }}'
+    metrics-server.image.tag: '{{ ("$RELATED_IMAGE_METRICS_SERVER" | split ":")._1
+      }}'
+    opentelemetry-operator.kubeRBACProxy.image.repository: '{{ ("$RELATED_IMAGE_KUBE_RBAC_PROXY"
+      | split ":")._0 }}'
+    opentelemetry-operator.kubeRBACProxy.image.tag: '{{ ("$RELATED_IMAGE_KUBE_RBAC_PROXY"
+      | split ":")._1 }}'
+    opentelemetry-operator.manager.image.repository: '{{ ("$RELATED_IMAGE_OPENTELEMETRY_OPERATOR"
+      | split ":")._0 }}'
+    opentelemetry-operator.manager.image.tag: '{{ ("$RELATED_IMAGE_OPENTELEMETRY_OPERATOR"
+      | split ":")._1 }}'
+    otelagent.daemonset.image.repository: '{{ ("$RELATED_IMAGE_SUMOLOGIC_OTEL_COLLECTOR"
+      | split ":")._0 }}'
+    otelagent.daemonset.image.tag: '{{ ("$RELATED_IMAGE_SUMOLOGIC_OTEL_COLLECTOR"
+      | split ":")._1 }}'
+    otelcol.deployment.image.repository: '{{ ("$RELATED_IMAGE_SUMOLOGIC_OTEL_COLLECTOR"
+      | split ":")._0 }}'
+    otelcol.deployment.image.tag: '{{ ("$RELATED_IMAGE_SUMOLOGIC_OTEL_COLLECTOR" |
+      split ":")._1 }}'
+    sumologic.setup.job.image.repository: '{{ ("$RELATED_IMAGE_KUBERNETES_SETUP" |
+      split ":")._0 }}'
+    sumologic.setup.job.image.tag: '{{ ("$RELATED_IMAGE_KUBERNETES_SETUP" | split
+      ":")._1 }}'
+    tailing-sidecar-operator.kubeRbacProxy.image.repository: '{{ ("$RELATED_IMAGE_KUBE_RBAC_PROXY"
+      | split ":")._0 }}'
+    tailing-sidecar-operator.kubeRbacProxy.image.tag: '{{ ("$RELATED_IMAGE_KUBE_RBAC_PROXY"
+      | split ":")._1 }}'
+    tailing-sidecar-operator.operator.image.repository: '{{ ("$RELATED_IMAGE_TAILING_SIDECAR_OPERATOR"
+      | split ":")._0 }}'
+    tailing-sidecar-operator.operator.image.tag: '{{ ("$RELATED_IMAGE_TAILING_SIDECAR_OPERATOR"
+      | split ":")._1 }}'
+    tailing-sidecar-operator.sidecar.image.repository: '{{ ("$RELATED_IMAGE_TAILING_SIDECAR"
+      | split ":")._0 }}'
+    tailing-sidecar-operator.sidecar.image.tag: '{{ ("$RELATED_IMAGE_TAILING_SIDECAR"
+      | split ":")._1 }}'
+    telegraf-operator.image.repository: '{{ ("$RELATED_IMAGE_TELEGRAF_OPERATOR" |
+      split ":")._0 }}'
     telegraf-operator.image.sidecarImage: $RELATED_IMAGE_TELEGRAF
-    tailing-sidecar-operator.operator.image.repository: '{{ ("$RELATED_IMAGE_TAILING_SIDECAR_OPERATOR" | split ":")._0 }}'
-    tailing-sidecar-operator.operator.image.tag: '{{ ("$RELATED_IMAGE_TAILING_SIDECAR_OPERATOR" | split ":")._1 }}'
-    tailing-sidecar-operator.sidecar.image.repository: '{{ ("$RELATED_IMAGE_TAILING_SIDECAR" | split ":")._0 }}'
-    tailing-sidecar-operator.sidecar.image.tag: '{{ ("$RELATED_IMAGE_TAILING_SIDECAR" | split ":")._1 }}'
-    tailing-sidecar-operator.kubeRbacProxy.image.repository: '{{ ("$RELATED_IMAGE_KUBE_RBAC_PROXY" | split ":")._0 }}'
-    tailing-sidecar-operator.kubeRbacProxy.image.tag: '{{ ("$RELATED_IMAGE_KUBE_RBAC_PROXY" | split ":")._1 }}'
-    opentelemetry-operator.manager.image.repository: '{{ ("$RELATED_IMAGE_OPENTELEMETRY_OPERATOR" | split ":")._0 }}'
-    opentelemetry-operator.manager.image.tag: '{{ ("$RELATED_IMAGE_OPENTELEMETRY_OPERATOR" | split ":")._1 }}'
-    opentelemetry-operator.kubeRBACProxy.image.repository: '{{ ("$RELATED_IMAGE_KUBE_RBAC_PROXY" | split ":")._0 }}'
-    opentelemetry-operator.kubeRBACProxy.image.tag: '{{ ("$RELATED_IMAGE_KUBE_RBAC_PROXY" | split ":")._1 }}'
-    metadata.image.repository: '{{ ("$RELATED_IMAGE_SUMOLOGIC_OTEL_COLLECTOR" | split ":")._0 }}'
-    metadata.image.tag: '{{ ("$RELATED_IMAGE_SUMOLOGIC_OTEL_COLLECTOR" | split ":")._1 }}'
-#+kubebuilder:scaffold:watch
+    telegraf-operator.image.tag: '{{ ("$RELATED_IMAGE_TELEGRAF_OPERATOR" | split ":")._1
+      }}'
+  version: v1alpha1


### PR DESCRIPTION
- Add script to generate  watches.yaml based on values.yaml for the Sumo Logic Kubernetes Collection Helm Chart
   Environment variables related to new image keys need to be manually filled out.
- Sort existing watches.yaml using `yaml.safe_load` and `yaml.safe_dump`
- Small fixes and improvement in `scripts/get_image_config_keys.py`


Example watches.yaml generated by the script with missing environment variables:
```yaml
- chart: helm-charts/sumologic
  group: helm-operator.sumologic.com
  kind: SumologicCollection
  overrideValues:
    debug.sumologicMock.image.repository: ''
    debug.sumologicMock.image.tag: ''
    fluent-bit.image.repository: '{{ ("$RELATED_IMAGE_FLUENT_BIT" | split ":")._0
      }}'
    fluent-bit.image.tag: '{{ ("$RELATED_IMAGE_FLUENT_BIT" | split ":")._1 }}'
    fluentd.image.repository: '{{ ("$RELATED_IMAGE_KUBERNETES_FLUENTD" | split ":")._0
      }}'
    fluentd.image.tag: '{{ ("$RELATED_IMAGE_KUBERNETES_FLUENTD" | split ":")._1 }}'
    instrumentation.instrumentationJobImage.image.repository: ''
    instrumentation.instrumentationJobImage.image.tag: ''
    kube-prometheus-stack.kube-state-metrics.image.repository: '{{ ("$RELATED_IMAGE_KUBE_STATE_METRICS"
      | split ":")._0 }}'
    kube-prometheus-stack.kube-state-metrics.image.tag: '{{ ("$RELATED_IMAGE_KUBE_STATE_METRICS"
      | split ":")._1 }}'
    kube-prometheus-stack.prometheus-node-exporter.image.repository: '{{ ("$RELATED_IMAGE_NODE_EXPORTER"
      | split ":")._0 }}'
    kube-prometheus-stack.prometheus-node-exporter.image.tag: '{{ ("$RELATED_IMAGE_NODE_EXPORTER"
      | split ":")._1 }}'
    kube-prometheus-stack.prometheus.prometheusSpec.image.repository: '{{ ("$RELATED_IMAGE_PROMETHEUS"
      | split "@")._0 }}'
    kube-prometheus-stack.prometheus.prometheusSpec.image.sha: '{{ ("$RELATED_IMAGE_PROMETHEUS"
      | split ":")._1 }}'
    kube-prometheus-stack.prometheus.prometheusSpec.image.tag: v2.22.1
    kube-prometheus-stack.prometheus.prometheusSpec.thanos.image: $RELATED_IMAGE_THANOS
    kube-prometheus-stack.prometheusOperator.image.repository: '{{ ("$RELATED_IMAGE_PROMETHEUS_OPERATOR"
      | split "@")._0 }}'
    kube-prometheus-stack.prometheusOperator.image.sha: '{{ ("$RELATED_IMAGE_PROMETHEUS_OPERATOR"
      | split ":")._1 }}'
    kube-prometheus-stack.prometheusOperator.image.tag: v0.44.0
    kube-prometheus-stack.prometheusOperator.prometheusConfigReloader.image.repository: ''
    kube-prometheus-stack.prometheusOperator.prometheusConfigReloaderImage.repository: '{{
      ("$RELATED_IMAGE_PROMETHEUS_CONFIG_RELOADER" | split "@")._0 }}'
    kube-prometheus-stack.prometheusOperator.prometheusConfigReloaderImage.sha: '{{
      ("$RELATED_IMAGE_PROMETHEUS_CONFIG_RELOADER" | split ":")._1 }}'
    kube-prometheus-stack.prometheusOperator.prometheusConfigReloaderImage.tag: v0.44.0
    kube-prometheus-stack.prometheusOperator.thanosImage.repository: ''
    kube-prometheus-stack.prometheusOperator.thanosImage.sha: ''
    kube-prometheus-stack.prometheusOperator.thanosImage.tag: ''
    metadata.image.repository: '{{ ("$RELATED_IMAGE_SUMOLOGIC_OTEL_COLLECTOR" | split
      ":")._0 }}'
    metadata.image.tag: '{{ ("$RELATED_IMAGE_SUMOLOGIC_OTEL_COLLECTOR" | split ":")._1
      }}'
    metrics-server.image.registry: '{{ ("$RELATED_IMAGE_METRICS_SERVER" | split "/")._0
      }}'
    metrics-server.image.repository: '{{ (("$RELATED_IMAGE_METRICS_SERVER" | split
      ":")._0 | split "/")._1 }}/{{ (("$RELATED_IMAGE_METRICS_SERVER" | split ":")._0
      | split "/")._2 }}'
    metrics-server.image.tag: '{{ ("$RELATED_IMAGE_METRICS_SERVER" | split ":")._1
      }}'
    opentelemetry-operator.kubeRBACProxy.image.repository: '{{ ("$RELATED_IMAGE_KUBE_RBAC_PROXY"
      | split ":")._0 }}'
    opentelemetry-operator.kubeRBACProxy.image.repository.tag: ''
    opentelemetry-operator.kubeRBACProxy.image.tag: '{{ ("$RELATED_IMAGE_KUBE_RBAC_PROXY"
      | split ":")._1 }}'
    opentelemetry-operator.manager.autoInstrumentationImage.dotnet.repository: ''
    opentelemetry-operator.manager.autoInstrumentationImage.dotnet.tag: ''
    opentelemetry-operator.manager.autoInstrumentationImage.java.repository: ''
    opentelemetry-operator.manager.autoInstrumentationImage.java.tag: ''
    opentelemetry-operator.manager.autoInstrumentationImage.nodejs.repository: ''
    opentelemetry-operator.manager.autoInstrumentationImage.nodejs.tag: ''
    opentelemetry-operator.manager.autoInstrumentationImage.python.repository: ''
    opentelemetry-operator.manager.autoInstrumentationImage.python.tag: ''
    opentelemetry-operator.manager.collectorImage.repository: ''
    opentelemetry-operator.manager.collectorImage.tag: ''
    opentelemetry-operator.manager.image.repository: '{{ ("$RELATED_IMAGE_OPENTELEMETRY_OPERATOR"
      | split ":")._0 }}'
    opentelemetry-operator.manager.image.repository.tag: ''
    opentelemetry-operator.manager.image.tag: '{{ ("$RELATED_IMAGE_OPENTELEMETRY_OPERATOR"
      | split ":")._1 }}'
    opentelemetry-operator.testFramework.image.repository: ''
    opentelemetry-operator.testFramework.image.repository.tag: ''
    otelagent.daemonset.image.repository: '{{ ("$RELATED_IMAGE_SUMOLOGIC_OTEL_COLLECTOR"
      | split ":")._0 }}'
    otelagent.daemonset.image.tag: '{{ ("$RELATED_IMAGE_SUMOLOGIC_OTEL_COLLECTOR"
      | split ":")._1 }}'
    otelcol.deployment.image.repository: '{{ ("$RELATED_IMAGE_SUMOLOGIC_OTEL_COLLECTOR"
      | split ":")._0 }}'
    otelcol.deployment.image.tag: '{{ ("$RELATED_IMAGE_SUMOLOGIC_OTEL_COLLECTOR" |
      split ":")._1 }}'
    otelcolInstrumentation.statefulset.image.repository: ''
    otelcolInstrumentation.statefulset.image.tag: ''
    otelevents.image.repository: ''
    otelevents.image.tag: ''
    otellogs.daemonset.initContainers.changeowner.image.repository: ''
    otellogs.daemonset.initContainers.changeowner.image.tag: ''
    otellogs.image.repository: ''
    otellogs.image.tag: ''
    otellogswindows.daemonset.initContainers.prepare.image.repository: ''
    otellogswindows.daemonset.initContainers.prepare.image.tag: ''
    otellogswindows.image.repository: ''
    otellogswindows.image.tag: ''
    pvcCleaner.job.image.repository: ''
    pvcCleaner.job.image.tag: ''
    sumologic.metrics.collector.otelcol.image.repository: ''
    sumologic.metrics.collector.otelcol.image.tag: ''
    sumologic.metrics.remoteWriteProxy.image.repository: ''
    sumologic.metrics.remoteWriteProxy.image.tag: ''
    sumologic.otelcolImage.repository: ''
    sumologic.otelcolImage.tag: ''
    sumologic.setup.job.image.repository: '{{ ("$RELATED_IMAGE_KUBERNETES_SETUP" |
      split ":")._0 }}'
    sumologic.setup.job.image.tag: '{{ ("$RELATED_IMAGE_KUBERNETES_SETUP" | split
      ":")._1 }}'
    sumologic.setup.job.initContainerImage.repository: ''
    sumologic.setup.job.initContainerImage.tag: ''
    tailing-sidecar-operator.kubeRbacProxy.image.repository: '{{ ("$RELATED_IMAGE_KUBE_RBAC_PROXY"
      | split ":")._0 }}'
    tailing-sidecar-operator.kubeRbacProxy.image.tag: '{{ ("$RELATED_IMAGE_KUBE_RBAC_PROXY"
      | split ":")._1 }}'
    tailing-sidecar-operator.operator.image.repository: '{{ ("$RELATED_IMAGE_TAILING_SIDECAR_OPERATOR"
      | split ":")._0 }}'
    tailing-sidecar-operator.operator.image.tag: '{{ ("$RELATED_IMAGE_TAILING_SIDECAR_OPERATOR"
      | split ":")._1 }}'
    tailing-sidecar-operator.sidecar.image.repository: '{{ ("$RELATED_IMAGE_TAILING_SIDECAR"
      | split ":")._0 }}'
    tailing-sidecar-operator.sidecar.image.tag: '{{ ("$RELATED_IMAGE_TAILING_SIDECAR"
      | split ":")._1 }}'
    telegraf-operator.image.repository: '{{ ("$RELATED_IMAGE_TELEGRAF_OPERATOR" |
      split ":")._0 }}'
    telegraf-operator.image.sidecarImage: $RELATED_IMAGE_TELEGRAF
    telegraf-operator.image.tag: '{{ ("$RELATED_IMAGE_TELEGRAF_OPERATOR" | split ":")._1
      }}'
    tracesGateway.deployment.image.repository: ''
    tracesGateway.deployment.image.tag: ''
    tracesSampler.deployment.image.repository: ''
    tracesSampler.deployment.image.tag: ''
  version: v1alpha1
```