### PR TITLE
Update digest for Helm Operator and kube-rbac-proxy in clusterserviceversion

### DIFF
--- a/bundle/manifests/operator.clusterserviceversion.yaml
+++ b/bundle/manifests/operator.clusterserviceversion.yaml
@@ -497,7 +497,7 @@ spec:
     name: Sumo Logic
     url: https://www.sumologic.com/
   relatedImages:
-  - image: registry.connect.redhat.com/sumologic/sumologic-kubernetes-collection-helm-operator@sha256:3a8af118243308c704119200b5a561072ed185703c5131e1e1fc78fcf661808a
+  - image: registry.connect.redhat.com/sumologic/sumologic-kubernetes-collection-helm-operator@sha256:f5bda9fe35c32141b1af41785e8b2ddfe386bd4ceef6209bdeb67d60d8becbaf
     name: sumologic-kubernetes-collection-helm-operator
   - image: registry.connect.redhat.com/sumologic/autoinstrumentation-dotnet@sha256:e99182dd7c0c8611cdc852bcc2e0866e635077b50b7e739022269cc8721f4109
     name: RELATED_IMAGE_AUTOINSTRUMENTATION_DOTNET

--- a/bundle/manifests/operator.clusterserviceversion.yaml
+++ b/bundle/manifests/operator.clusterserviceversion.yaml
@@ -354,7 +354,7 @@ spec:
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=10
-                image: registry.connect.redhat.com/sumologic/kube-rbac-proxy@sha256:c1ea7aa4873a78d8d506e4dab8c281c6c72a65d1374312cd76b27ed881b043b5
+                image: registry.connect.redhat.com/sumologic/kube-rbac-proxy@sha256:6081af347a86a9cd51232f60e9f5567bdaddf0377927a462ced91524ce80bf95
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443


### PR DESCRIPTION
Related to failure in https://github.com/redhat-openshift-ecosystem/certified-operators/pull/4178