### PR TITLE
fix: remove redundant catalog-render-fbc step from dev builds

### DIFF
--- a/.github/workflows/dev_builds.yaml
+++ b/.github/workflows/dev_builds.yaml
@@ -80,11 +80,6 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_CATALOG_DEV }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_CATALOG_DEV }}
 
-      - name: Render new bundle into FBC catalog directory
-        run: |
-          make catalog-render-fbc \
-            BUNDLE_IMGS=${ECR_URL}/${BUNDLE_IMAGE_NAME}:${{ steps.extract_tag.outputs.tag }}
-
       - name: Build and push catalog image (FBC)
         run: make catalog-build-fbc catalog-push \
           CATALOG_IMG=${ECR_URL}/${CATALOG_IMAGE_NAME}:${{ steps.extract_tag.outputs.tag }}


### PR DESCRIPTION
fixes this -> https://github.com/SumoLogic/sumologic-kubernetes-collection-helm-operator/actions/runs/24554026386/job/71786062616

Dev builds re-use the already-committed bundles.yaml (which contains
the v4.21.0-0 bundle). Running catalog-render-fbc would append a
duplicate bundle document causing 'opm validate' to fail with:
  package has duplicate bundle sumologic-kubernetes-collection-helm-operator.v4.21.0-0

The render step only belongs in release builds where a new bundle
version is appended to bundles.yaml.